### PR TITLE
Update nss-cfi patch for kernel 6.6

### DIFF
--- a/target/linux/qualcommax/patches-6.6/0605-1-qca-nss-cfi-support.patch
+++ b/target/linux/qualcommax/patches-6.6/0605-1-qca-nss-cfi-support.patch
@@ -1,6 +1,6 @@
 --- a/crypto/authenc.c
 +++ b/crypto/authenc.c
-@@ -415,6 +415,8 @@ static int crypto_authenc_create(struct
+@@ -417,6 +417,8 @@ static int crypto_authenc_create(struct
  		     enc->base.cra_driver_name) >= CRYPTO_MAX_ALG_NAME)
  		goto err_free_inst;
  
@@ -11,7 +11,7 @@
  	inst->alg.base.cra_blocksize = enc->base.cra_blocksize;
 --- a/include/linux/crypto.h
 +++ b/include/linux/crypto.h
-@@ -86,6 +86,11 @@
+@@ -101,6 +101,11 @@
  #define CRYPTO_NOLOAD			0x00008000
  
  /*
@@ -25,6 +25,14 @@
   * flag unset if they can't handle memory allocation failures.
 --- a/net/ipv4/esp4.c
 +++ b/net/ipv4/esp4.c
+@@ -3,6 +3,7 @@
+
+ #include <crypto/aead.h>
+ #include <crypto/authenc.h>
++#include <crypto/algapi.h>
+ #include <linux/err.h>
+ #include <linux/module.h>
+ #include <net/ip.h>
 @@ -658,6 +658,7 @@ static int esp_output(struct xfrm_state
  	struct ip_esp_hdr *esph;
  	struct crypto_aead *aead;
@@ -68,6 +76,14 @@
  
 --- a/net/ipv6/esp6.c
 +++ b/net/ipv6/esp6.c
+@@ -15,6 +15,7 @@
+
+ #include <crypto/aead.h>
+ #include <crypto/authenc.h>
++#include <crypto/algapi.h>
+ #include <linux/err.h>
+ #include <linux/module.h>
+ #include <net/ip.h>
 @@ -696,6 +696,7 @@ static int esp6_output(struct xfrm_state
  	struct ip_esp_hdr *esph;
  	struct crypto_aead *aead;


### PR DESCRIPTION
@qosmio hello, i tried to build fw for nbg7815 with enabled nss-cfi and got error:
```
make[5]: Entering directory '/mnt/ssd_storage/openwrt/zyxel/qosmio/nnmn/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/linux-6.6.22'
  AR      net/ipv4/built-in.a
  LD [M]  net/ipv4/gre.o
  LD [M]  net/ipv4/udp_tunnel.o
  CC [M]  net/ipv4/esp4.o
net/ipv4/esp4.c: In function 'esp_output':
net/ipv4/esp4.c:673:21: error: implicit declaration of function 'crypto_tfm_alg_type'; did you mean 'crypto_tfm_alg_name'? [-Werror=implicit-function-declaration]
  673 |         nosupp_sg = crypto_tfm_alg_type(&aead->base) & CRYPTO_ALG_NOSUPP_SG;
      |                     ^~~~~~~~~~~~~~~~~~~
      |                     crypto_tfm_alg_name
cc1: some warnings being treated as errors
make[9]: *** [scripts/Makefile.build:243: net/ipv4/esp4.o] Error 1
make[8]: *** [scripts/Makefile.build:480: net/ipv4] Error 2
make[7]: *** [scripts/Makefile.build:480: net] Error 2
```
this is a fixed patch for  kernel 6.6