### PR TITLE
kernel-build.mk: Fix multi-core build warning.

### DIFF
--- a/include/kernel-build.mk
+++ b/include/kernel-build.mk
@@ -154,7 +154,7 @@ define BuildKernel
   download: $(if $(LINUX_SITE),$(DL_DIR)/$(LINUX_SOURCE))
   prepare: $(STAMP_PREPARED)
   compile: $(LINUX_DIR)/.modules
-	$(MAKE) -C image compile TARGET_BUILD=
+	+$(MAKE) -C image compile TARGET_BUILD=
 
   dtb: $(STAMP_CONFIGURED)
 	$(_SINGLE)$(KERNEL_MAKE) scripts_dtc


### PR DESCRIPTION
In the case of multi-core compilation, the warning prompts to add a "+" sign.

````
warning: jobserver unavailable: using -j1. Add `+' to parent make rule.
````
