### PR TITLE
Fix L2TP PPP refcount handling in l2tp_ppp.c

### DIFF
--- a/target/linux/qualcommax/patches-6.12/0607-3-qca-nss-clients-fix-l2tp-ppp-refcount.patch
+++ b/target/linux/qualcommax/patches-6.12/0607-3-qca-nss-clients-fix-l2tp-ppp-refcount.patch
@@ -1,0 +1,35 @@
+--- a/net/l2tp/l2tp_ppp.c
++++ b/net/l2tp/l2tp_ppp.c
+@@ -1774,13 +1774,13 @@
+ 
+ 	tunnel = session->tunnel;
+ 	if (!tunnel) {
+-		sock_put(sk);
++		l2tp_session_put(session);
+ 		return -1;
+ 	}
+ 
+ 	version = tunnel->version;
+ 
+-	sock_put(sk);
++	l2tp_session_put(session);
+ 
+ 	return version;
+ }
+@@ -1802,7 +1802,7 @@
+ 
+ 	tunnel = session->tunnel;
+ 	if (!tunnel) {
+-		sock_put(sk);
++		l2tp_session_put(session);
+ 		return err;
+ 	}
+ 	isk = inet_sk(tunnel->sock);
+@@ -1817,7 +1817,7 @@
+ 	addr->local_addr.sin_addr.s_addr = isk->inet_saddr;
+ 	addr->remote_addr.sin_addr.s_addr = isk->inet_daddr;
+ 
+-	sock_put(sk);
++	l2tp_session_put(session);
+ 	return 0;
+ }


### PR DESCRIPTION
Fix reference counting for L2TP PPP sessions by adjusting sock_put and l2tp_session_put calls. In patch 0603-2-net-l2tp-add-helper-functions.patch, the functions pppol2tp_get_channel_protocol_ver() and pppol2tp_get_addressing() incorrectly use sock_put(sk) without a corresponding sock_hold().

The function pppol2tp_sock_to_session() increments the session refcount, not the socket refcount. The caller must call l2tp_session_put(session) to release it.
